### PR TITLE
Added tests and basic integration with Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+
+sudo: false
+
+python:
+  - "3.5"
+  - "3.6"
+
+install:
+  - pip install -U -r requirements.txt
+  - pip install pytest
+
+script:
+  py.test --verbose --color=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,10 @@ language: python
 sudo: false
 
 python:
-  - "3.5"
   - "3.6"
 
 install:
-  - pip install -U -r requirements.txt
-  - pip install pytest
+  - pip install -r requirements.txt
 
 script:
   py.test --verbose --color=yes

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ ujson==1.35               # via sanic
 uvloop==0.8.0             # via sanic
 websockets==3.3           # via sanic
 yarl==0.10.0              # via aiohttp
+pytest=3.0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ ujson==1.35               # via sanic
 uvloop==0.8.0             # via sanic
 websockets==3.3           # via sanic
 yarl==0.10.0              # via aiohttp
-pytest=3.0.7
+pytest==3.0.7

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,37 @@
+import pytest
+
+from sanic.exceptions import NotFound
+from sanic.response import text
+
+
+@pytest.fixture(scope='module')
+def app():
+    from app import app
+    return app
+
+
+def test_resource_is_ok(app):
+    _, response = app.test_client.get('/api/food/dish')
+    assert response.status == 200
+
+
+def test_bad_resource(app):
+    _, response = app.test_client.get('/not_found_404')
+    assert response.status == 404
+
+
+def test_bad_sub_name(app):
+    _, response = app.test_client.get("/api/food/badsubmane")
+    assert response.status == 404
+
+
+def test_catch_not_found_404(app):
+    @app.exception([NotFound])
+    def exception_list(request, exception):
+        return text("ok")
+
+    request, response = app.test_client.get('/not_found_404')
+    assert response.text == "ok"
+
+    request, response = app.test_client.get('/api/food/dich')
+    assert response.text == "ok"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -28,10 +28,10 @@ def test_bad_sub_name(app):
 def test_catch_not_found_404(app):
     @app.exception([NotFound])
     def exception_list(request, exception):
-        return text("ok")
+        return text("not_found")
 
-    request, response = app.test_client.get('/not_found_404')
-    assert response.text == "ok"
+    _, response = app.test_client.get('/not_found_404')
+    assert response.text == "not_found"
 
-    request, response = app.test_client.get('/api/food/dich')
-    assert response.text == "ok"
+    _, response = app.test_client.get('/api/food/dich')
+    assert response.text == "not_found"


### PR DESCRIPTION
Has been added following tests:
 - 404 is raised for a bad resource (tested status codes and text response)
-  404 is raised for a bad sub-name (tested status codes and text response)
- returns 200 when resource is `OK`

I use [this](https://github.com/channelcat/sanic/blob/c9ce33dfe69774d9630f2ed27ce1fa37533305a7/tests/test_exceptions.py#L82-L85) tests as good examples. The core Sanic developers recommend the similar [way](https://github.com/channelcat/sanic/issues/658) to testing Sanic endpoints.

I added to `.travis.yml` only Python 3.5+ cuz happen [this](https://travis-ci.org/wemake-services/elizabeth-cloud/jobs/225269039#L162) when i added Python 2.7, 3.4.