### PR TITLE
Rename project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# elizabeth-cloud
+# mimesis-cloud
 
 [![Build Status](https://travis-ci.org/wemake-services/elizabeth-cloud.svg?branch=master)](https://travis-ci.org/wemake-services/elizabeth-cloud) [![Coverage Status](https://coveralls.io/repos/github/wemake-services/elizabeth-cloud/badge.svg?branch=master)](https://coveralls.io/github/wemake-services/elizabeth-cloud?branch=master)
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 # Runtime requirements:
 
-elizabeth==0.3.28
+mimesis==1.0.4
 graphene==1.4
 sanic==0.5.1
 sanic-cors==0.5.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ apipkg==1.4               # via execnet
 async-timeout==1.2.0      # via aiohttp
 chardet==3.0.2            # via aiohttp
 coverage==4.3.4           # via pytest-cov
-elizabeth==0.3.28
 execnet==1.4.1            # via pytest-cache
 flake8-builtins==0.2
 flake8-commas==0.4.3
@@ -23,6 +22,7 @@ graphql-server-core==1.0.dev20170322001  # via sanic-graphql
 httptools==0.0.9          # via sanic
 isort==4.2.5              # via pytest-isort
 mccabe==0.6.1             # via flake8
+mimesis==1.0.4
 multidict==2.1.4          # via aiohttp, yarl
 promise==2.0.2            # via graphene, graphql-core, graphql-relay, graphql-server-core
 py==1.4.33                # via pytest

--- a/src/app.py
+++ b/src/app.py
@@ -8,7 +8,7 @@ from server.graphql import view
 
 
 # Core:
-app = Sanic('elizabeth-cloud')
+app = Sanic('mimesis-cloud')
 app.config.update(settings.as_dict())
 app.blueprint(api)
 app.add_route(view, '/ql')

--- a/src/server/api.py
+++ b/src/server/api.py
@@ -1,4 +1,4 @@
-from elizabeth import Generic
+from mimesis import Generic
 
 from sanic import Blueprint, response
 from sanic.exceptions import NotFound
@@ -15,14 +15,14 @@ api = Blueprint('api', url_prefix='/api')
 async def handle_resource(request: Request,
                           resource: str, sub: str) -> HTTPResponse:
     """
-    This route is a wrapper of :class:`elizabeth.Generic`.
+    This route is a wrapper of :class:`mimesis.Generic`.
     It is used to serve different data over the REST API.
 
     Args:
         request: Sanic's request instance
         resource: first part of the url,
-            name of elizabeth's resource
-        sub: subname of the elizabeth's resource
+            name of mimesis's resource
+        sub: subname of the mimesis's resource
 
     Returns:
         HTTPResponse: Sanic's response with json body,

--- a/src/server/graphql/schema.py
+++ b/src/server/graphql/schema.py
@@ -1,22 +1,22 @@
 import graphene
 
-from elizabeth import Generic
+from mimesis import Generic
 
-from .types import ElizabethType
+from .types import MimesisType
 
 
-class Elizabeth(ElizabethType):
+class Mimesis(MimesisType):
     pass
 
 
 class Query(graphene.ObjectType):
-    elizabeth = graphene.Field(
-        Elizabeth,
+    mimesis = graphene.Field(
+        Mimesis,
         required=True,
         locale=graphene.String(),
     )
 
-    def resolve_elizabeth(self, context, *args, **kwargs):
+    def resolve_mimesis(self, context, *args, **kwargs):
         return Generic(context.get('locale', 'en'))
 
 

--- a/src/server/graphql/types.py
+++ b/src/server/graphql/types.py
@@ -5,13 +5,12 @@ from functools import partial
 
 import graphene
 
-from elizabeth import Generic
-
 from graphene import Field, ObjectType, String
 from graphene.types.objecttype import ObjectTypeMeta
 from graphene.types.options import Options
 from graphene.types.utils import merge
 from graphene.utils.is_base_type import is_base_type
+from mimesis import Generic
 
 
 def get_fields(instance, callables=False):
@@ -120,5 +119,5 @@ class GenericTypeMeta(ObjectTypeMeta):
         return cls
 
 
-class ElizabethType(ObjectType, metaclass=GenericTypeMeta):
+class MimesisType(ObjectType, metaclass=GenericTypeMeta):
     pass


### PR DESCRIPTION
Rename project from elizabeth-cloud to mimesis-cloud. It's necessary
because original library elizabeth was renamed to mimesis.